### PR TITLE
Fixed NullReferenceException in ExtendedHttpTracerHandler.cs

### DIFF
--- a/Apizr/Src/Apizr/Logging/ExtendedHttpTracerHandler.cs
+++ b/Apizr/Src/Apizr/Logging/ExtendedHttpTracerHandler.cs
@@ -275,7 +275,7 @@ namespace Apizr.Logging
                 && InnerHandler is HttpClientHandler httpClientHandler)
             {
                 if (!httpClientHandler.UseCookies) return httpRequestHeaders;
-                var cookieHeader = httpClientHandler.CookieContainer.GetCookieHeader(request.RequestUri);
+                var cookieHeader = httpClientHandler.CookieContainer?.GetCookieHeader(request.RequestUri);
                 if (!string.IsNullOrWhiteSpace(cookieHeader))
                 {
                     httpRequestHeaders += $"{Environment.NewLine}Cookie: {cookieHeader}";


### PR DESCRIPTION
CookieContainer can be null. Check for null before accessing the GetCookieHeader method