### PR TITLE
consider CacheKey always when searching, handle null string gracefully in Distributed cache.

### DIFF
--- a/Apizr/Src/Apizr/ApizrManager.cs
+++ b/Apizr/Src/Apizr/ApizrManager.cs
@@ -2167,16 +2167,7 @@ namespace Apizr
             {
                 var methodToCacheData = methodDetails;
 
-                // Did we ask for it already ?
-                if (_cachingMethodsSet.TryGetValue(methodToCacheData, out var methodCacheDetails))
-                {
-                    // Yes we did so get saved specific details
-                    cacheAttribute = methodCacheDetails.cacheAttribute;
-                    cacheKey = methodCacheDetails.cacheKey;
-
-                    return cacheAttribute != null && !string.IsNullOrWhiteSpace(cacheKey);
-                }
-
+            
                 cacheAttribute = null;
                 cacheKey = null;
 
@@ -2216,7 +2207,7 @@ namespace Apizr
                 if (cacheAttribute == null || cacheAttribute.Mode == CacheMode.None)
                 {
                     // No we're not! Save details for next calls and return False
-                    _cachingMethodsSet.TryAdd(methodToCacheData, (cacheAttribute, cacheKey));
+                    _cachingMethodsSet.GetOrAdd(methodToCacheData, (cacheAttribute, cacheKey));
                     return false;
                 }
 
@@ -2237,7 +2228,7 @@ namespace Apizr
                     cacheKey += ")";
 
                     // Save details for next calls and return False
-                    _cachingMethodsSet.TryAdd(methodToCacheData, (cacheAttribute, cacheKey));
+                    _cachingMethodsSet.GetOrAdd(methodToCacheData, (cacheAttribute, cacheKey));
                     return true;
                 }
 
@@ -2324,7 +2315,7 @@ namespace Apizr
                 cacheKey += $"{string.Join(", ", parameters)})";
 
                 // Save details for next calls and return False
-                _cachingMethodsSet.TryAdd(methodToCacheData, (cacheAttribute, cacheKey));
+                _cachingMethodsSet.GetOrAdd(methodToCacheData, (cacheAttribute, cacheKey));
                 return true;
             }
         }

--- a/Apizr/Src/Caching/Apizr.Extensions.Microsoft.Caching/SerializationExtensions.cs
+++ b/Apizr/Src/Caching/Apizr.Extensions.Microsoft.Caching/SerializationExtensions.cs
@@ -42,6 +42,10 @@ namespace Apizr
 
         internal static async Task<T> FromJsonStringAsync<T>(this string str, IHttpContentSerializer contentSerializer, CancellationToken cancellationToken = default)
         {
+            if (str == null)
+            {
+                return default;
+            }
             var content = new StringContent(str, Encoding.UTF8, "application/json");
             return await contentSerializer.FromHttpContentAsync<T>(content, cancellationToken);
         }


### PR DESCRIPTION
The CacheKey was not being considered when looking for saved cache items in _cachingMethodsSet.

As such it may even be pointless to save stuff in _cachingMethodsSet, consider just getting rid of it.