### PR TITLE
Refine response logging to target non-successful requests in limited

### DIFF
--- a/Apizr/Src/Apizr/Logging/ExtendedHttpTracerHandler.cs
+++ b/Apizr/Src/Apizr/Logging/ExtendedHttpTracerHandler.cs
@@ -120,7 +120,8 @@ namespace Apizr.Logging
                         await LogHttpErrorRequest(request, logger, logLevels, verbosity, shouldRedactHeaderValue).ConfigureAwait(false);
                     }
 
-                    if(verbosity.HasResponseFlags())
+                    if(verbosity.HasResponseFlags() && 
+                       (tracerMode == HttpTracerMode.Everything || !response.IsSuccessStatusCode))
                         await LogHttpResponse(response, stopwatch.Elapsed, logger, logLevels, verbosity, shouldRedactHeaderValue).ConfigureAwait(false);  
                 }
 


### PR DESCRIPTION
This fixes the issue 31 by adding checks for failure and modes before logging responses